### PR TITLE
Add web server to serve files

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -29,4 +29,4 @@ jobs:
           pixi-version: v0.56.0
           cache: true
       - name: Test example
-        run: pixi run repo2wasm ${{ matrix.example_path }}
+        run: pixi run repo2wasm ${{ matrix.example_path }} --no-run

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,6 +4,7 @@
 
 ### Enhancements made
 
+- Run local server after build
 - Upgrade JupyterLite to 0.7.0
 - Jupyter Notebook as IDE is supported
 - Raise exception for `irkernel`

--- a/docs/source/get-started.md
+++ b/docs/source/get-started.md
@@ -27,15 +27,8 @@ We'll use a fork of [Binder `requirements` example](https://github.com/repo2wasm
 repo2wasm https://github.com/repo2wasm/requirements
 ```
 
-A new directory `public` will be created.
+A new directory `public` will be created and a local web server will start. Open <http://localhost:8000>.
 
-## Launch JupyterLite
-
-Run
-
-```bash
-cd public
-python -m http.server
+```{note}
+To not start the local web server, use `--no-run`.
 ```
-
-and open <http://localhost:8000>.


### PR DESCRIPTION
This is to improve the compatibility between the command line arguments between `repo2was` and `repo2docker`.